### PR TITLE
perf: add session cache to improve tls efficiency

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -17,6 +17,7 @@ package vault
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
@@ -35,7 +36,8 @@ import (
 )
 
 const (
-	defaultJWTFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	defaultJWTFile       = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	sessionCacheCapacity = 64
 )
 
 // NewData is a helper function for Vault KV Version two secret data creation
@@ -573,6 +575,7 @@ func NewInsecureRawClient() (*vaultapi.Client, error) {
 
 	config.HttpClient.Transport.(*http.Transport).TLSHandshakeTimeout = 5 * time.Second
 	config.HttpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+	config.HttpClient.Transport.(*http.Transport).TLSClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(sessionCacheCapacity)
 
 	return vaultapi.NewClient(config)
 }


### PR DESCRIPTION
To improve efficiency in tls mode, session cache allows to reuse tls session. The default session cache is an LRU version, capacity has been defaulted at 64 (as implemented in official tls package).

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
