### PR TITLE
ci: update dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,9 +11,12 @@ updates:
       time: "16:00"
     open-pull-requests-limit: 10
     groups:
-      auth:
+      vault/api/auth:
         patterns:
-          - "github.com/hashicorp/vault/api/auth"
+          - "github.com/hashicorp/vault/api/auth/aws"
+          - "github.com/hashicorp/vault/api/auth/azure"
+          - "github.com/hashicorp/vault/api/auth/gcp"
+          - "github.com/hashicorp/vault/api/auth/kubernetes"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,10 +13,7 @@ updates:
     groups:
       vault/api/auth:
         patterns:
-          - "github.com/hashicorp/vault/api/auth/aws"
-          - "github.com/hashicorp/vault/api/auth/azure"
-          - "github.com/hashicorp/vault/api/auth/gcp"
-          - "github.com/hashicorp/vault/api/auth/kubernetes"
+          - "github.com/hashicorp/vault/api/auth/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Overview

- The current dependabot config did not group dependencies together, either the `github.com/hashicorp/vault/api/auth/*` , or listing the dependencies would work.
