### PR TITLE
chore: enable bao injector tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
+  test-sdk:
+    name: Test-SDK
     runs-on: ubuntu-latest
     strategy:
       # Fail fast is disabled because there are Go version specific features and tests
@@ -32,13 +32,80 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Test
+      - name: Test-SDK
         env:
           VAULT_ADDR: "http://127.0.0.1:8200"
           VAULT_TOKEN: "227e1cce-6bf7-30bb-2d2a-acc854318caf"
           BAO_ADDR: "http://127.0.0.1:8300"
           BAO_TOKEN: "227e1cce-6bf7-30bb-2d2a-acc854318caf"
-        run: make test
+        run: make test-sdk
+
+  test-injector-vault:
+    name: Test-Injector-Vault
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@b46e247b898aa56e6d2d2e728dc6df6c84fdb738 # v7
+
+      - name: Set up Go cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-go-
+
+      - name: Prepare Nix shell
+        run: nix develop --impure .#ci
+
+      - name: Test-Injector-Vault
+        run: nix develop --impure .#ci -c make test-injector-vault
+
+
+  test-injector-bao:
+    name: Test-Injector-Bao
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@b46e247b898aa56e6d2d2e728dc6df6c84fdb738 # v7
+
+      - name: Set up Go cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-go-
+
+      - name: Prepare Nix shell
+        run: nix develop --impure .#ci
+
+      - name: Test-Injector-Bao
+        run: nix develop --impure .#ci -c make test-injector-bao
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,11 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Test
+        env:
+          VAULT_ADDR: "http://127.0.0.1:8200"
+          VAULT_TOKEN: "227e1cce-6bf7-30bb-2d2a-acc854318caf"
+          BAO_ADDR: "http://127.0.0.1:8300"
+          BAO_TOKEN: "227e1cce-6bf7-30bb-2d2a-acc854318caf"
         run: make test
 
   lint:

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,21 @@ lint-yaml:
 	yamllint $(if ${CI},-f github,) --no-warnings .
 
 .PHONY: test
-test: up ## Run tests
-	go test -race -v ./...
+test: test-sdk test-injector-vault test-injector-bao ## Run tests
+
+targets := $(shell go list ./... | grep -v '/injector')
+
+.PHONY: test-sdk
+test-sdk: ## Run tests for SDK
+	go test -race -v $(targets)
+
+.PHONY: test-injector-vault
+test-injector-vault: up ## Run tests for vault-injector
+	go test -race -v ./injector/vault
+
+.PHONY: test-injector-bao
+test-injector-bao: up ## Run tests for bao-injector
+	go test -race -v ./injector/bao
 
 .PHONY: license-check
 license-check: ## Run license check

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint-yaml:
 	yamllint $(if ${CI},-f github,) --no-warnings .
 
 .PHONY: test
-test: ## Run tests
+test: up ## Run tests
 	go test -race -v ./...
 
 .PHONY: license-check

--- a/injector/bao/injector_test.go
+++ b/injector/bao/injector_test.go
@@ -15,286 +15,295 @@
 package bao
 
 import (
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
+
+	baoapi "github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	bao "github.com/bank-vaults/vault-sdk/vault"
 )
 
-// func assertKeyDoesNotExist(t *testing.T, m map[string]string, k string) {
-// 	_, hasKey := m[k]
-// 	assert.False(t, hasKey)
-// }
-
-// Enable these tests once openbao has been released, and added to the ci as a service
-
-// func TestSecretInjector(t *testing.T) {
-// 	if addr := os.Getenv("BAO_ADDR"); addr == "" {
-// 		t.Skip("skipping test: no BAO_ADDR environment variable is set")
-// 	}
-
-// 	if testing.Short() {
-// 		t.Skip("skipping integration test due to -short")
-// 	}
-
-// 	config := baoapi.DefaultConfig()
-// 	if config.Error != nil {
-// 		assert.NoError(t, config.Error)
-// 	}
-
-// 	client, err := bao.NewClientFromConfig(config)
-// 	assert.NoError(t, err)
-
-// 	err = client.RawClient().Sys().Mount("transit", &baoapi.MountInput{Type: "transit"})
-// 	assert.NoError(t, err)
-
-// 	_, err = client.RawClient().Logical().Write("transit/keys/mykey", nil)
-// 	assert.NoError(t, err)
-
-// 	secret, err := client.RawClient().Logical().Write("transit/encrypt/mykey", map[string]interface{}{
-// 		"plaintext": base64.StdEncoding.EncodeToString([]byte("secret")),
-// 	})
-// 	assert.NoError(t, err)
-
-// 	ciphertext := secret.Data["ciphertext"].(string) //nolint:forcetypeassert
-
-// 	_, err = client.RawClient().Logical().Write("secret/data/account", bao.NewData(0, map[string]interface{}{"username": "superusername1", "password": "secret1"}))
-// 	assert.NoError(t, err)
-
-// 	_, err = client.RawClient().Logical().Write("secret/data/account", bao.NewData(1, map[string]interface{}{"username": "superusername", "password": "secret"}))
-// 	assert.NoError(t, err)
-
-// 	err = client.RawClient().Sys().Mount("pki", &baoapi.MountInput{Type: "pki"})
-// 	assert.NoError(t, err)
-
-// 	t.Cleanup(func() {
-// 		err = client.RawClient().Sys().Unmount("transit")
-// 		assert.NoError(t, err)
-
-// 		_, err = client.RawClient().Logical().Delete("secret/metadata/account")
-// 		assert.NoError(t, err)
-
-// 		err = client.RawClient().Sys().Unmount("pki")
-// 		assert.NoError(t, err)
-// 	})
-
-// 	injector := NewSecretInjector(Config{}, client, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
-
-// 	t.Run("success", func(t *testing.T) {
-// 		t.Parallel()
-
-// 		references := map[string]string{
-// 			"ACCOUNT_PASSWORD_1":              "bao:secret/data/account#password#1",
-// 			"ACCOUNT_PASSWORD":                "bao:secret/data/account#password",
-// 			"TRANSIT_SECRET":                  `>>bao:transit/decrypt/mykey#${.plaintext | b64dec}#{"ciphertext":"` + ciphertext + `"}`,
-// 			"ROOT_CERT":                       ">>bao:pki/root/generate/internal#certificate",
-// 			"ROOT_CERT_CACHED":                ">>bao:pki/root/generate/internal#certificate",
-// 			"INLINE_SECRET":                   "scheme://${bao:secret/data/account#username}:${bao:secret/data/account#password}@127.0.0.1:8080",
-// 			"INLINE_SECRET_EMBEDDED_TEMPLATE": "scheme://${bao:secret/data/account#username}:${bao:secret/data/account#${.password | urlquery}}@127.0.0.1:8080",
-// 			"INLINE_DYNAMIC_SECRET":           "${>>bao:pki/root/generate/internal#certificate}__${>>bao:pki/root/generate/internal#certificate}",
-// 		}
-
-// 		results := map[string]string{}
-// 		injectFunc := func(key, value string) {
-// 			assertKeyDoesNotExist(t, results, key)
-// 			results[key] = value
-// 		}
-
-// 		err := injector.InjectSecretsFromBao(references, injectFunc)
-// 		require.NoError(t, err)
-
-// 		// This tests caching of dynamic secrets in calls. We can't predict
-// 		// the value, but it is enough checking if they are present and equal.
-// 		assert.NotNil(t, results["ROOT_CERT"])
-// 		assert.Equal(t, results["ROOT_CERT"], results["ROOT_CERT_CACHED"])
-// 		delete(results, "ROOT_CERT")
-// 		delete(results, "ROOT_CERT_CACHED")
-
-// 		inlineCerts := strings.Split(results["INLINE_DYNAMIC_SECRET"], "__")
-// 		require.Equal(t, 2, len(inlineCerts), "two certs are expected")
-// 		assert.Equal(t, inlineCerts[0], inlineCerts[1], "the two certs should be the same")
-// 		delete(results, "INLINE_DYNAMIC_SECRET")
-
-// 		assert.Equal(t, map[string]string{
-// 			"ACCOUNT_PASSWORD_1":              "secret1",
-// 			"ACCOUNT_PASSWORD":                "secret",
-// 			"TRANSIT_SECRET":                  "secret",
-// 			"INLINE_SECRET":                   "scheme://superusername:secret@127.0.0.1:8080",
-// 			"INLINE_SECRET_EMBEDDED_TEMPLATE": "scheme://superusername:secret@127.0.0.1:8080",
-// 		}, results)
-// 	})
+func assertKeyDoesNotExist(t *testing.T, m map[string]string, k string) {
+	_, hasKey := m[k]
+	assert.False(t, hasKey)
+}
+
+func TestSecretInjector(t *testing.T) {
+	if addr := os.Getenv("BAO_ADDR"); addr == "" {
+		t.Skip("skipping test: no BAO_ADDR environment variable is set")
+	}
+
+	if testing.Short() {
+		t.Skip("skipping integration test due to -short")
+	}
+
+	config := baoapi.DefaultConfig()
+	if config.Error != nil {
+		assert.NoError(t, config.Error)
+	}
+
+	client, err := bao.NewClientFromConfig(config)
+	assert.NoError(t, err)
+
+	err = client.RawClient().Sys().Mount("transit", &baoapi.MountInput{Type: "transit"})
+	assert.NoError(t, err)
+
+	_, err = client.RawClient().Logical().Write("transit/keys/mykey", nil)
+	assert.NoError(t, err)
+
+	secret, err := client.RawClient().Logical().Write("transit/encrypt/mykey", map[string]interface{}{
+		"plaintext": base64.StdEncoding.EncodeToString([]byte("secret")),
+	})
+	assert.NoError(t, err)
+
+	ciphertext := secret.Data["ciphertext"].(string) //nolint:forcetypeassert
+
+	_, err = client.RawClient().Logical().Write("secret/data/account", bao.NewData(0, map[string]interface{}{"username": "superusername1", "password": "secret1"}))
+	assert.NoError(t, err)
+
+	_, err = client.RawClient().Logical().Write("secret/data/account", bao.NewData(1, map[string]interface{}{"username": "superusername", "password": "secret"}))
+	assert.NoError(t, err)
+
+	err = client.RawClient().Sys().Mount("pki", &baoapi.MountInput{Type: "pki"})
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = client.RawClient().Sys().Unmount("transit")
+		assert.NoError(t, err)
+
+		_, err = client.RawClient().Logical().Delete("secret/metadata/account")
+		assert.NoError(t, err)
+
+		err = client.RawClient().Sys().Unmount("pki")
+		assert.NoError(t, err)
+	})
+
+	injector := NewSecretInjector(Config{}, client, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		references := map[string]string{
+			"ACCOUNT_PASSWORD_1":              "bao:secret/data/account#password#1",
+			"ACCOUNT_PASSWORD":                "bao:secret/data/account#password",
+			"TRANSIT_SECRET":                  `>>bao:transit/decrypt/mykey#${.plaintext | b64dec}#{"ciphertext":"` + ciphertext + `"}`,
+			"ROOT_CERT":                       ">>bao:pki/root/generate/internal#certificate",
+			"ROOT_CERT_CACHED":                ">>bao:pki/root/generate/internal#certificate",
+			"INLINE_SECRET":                   "scheme://${bao:secret/data/account#username}:${bao:secret/data/account#password}@127.0.0.1:8080",
+			"INLINE_SECRET_EMBEDDED_TEMPLATE": "scheme://${bao:secret/data/account#username}:${bao:secret/data/account#${.password | urlquery}}@127.0.0.1:8080",
+			"INLINE_DYNAMIC_SECRET":           "${>>bao:pki/root/generate/internal#certificate}__${>>bao:pki/root/generate/internal#certificate}",
+		}
+
+		results := map[string]string{}
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
+
+		err := injector.InjectSecretsFromBao(references, injectFunc)
+		require.NoError(t, err)
+
+		// This tests caching of dynamic secrets in calls. We can't predict
+		// the value, but it is enough checking if they are present and equal.
+		assert.NotNil(t, results["ROOT_CERT"])
+		assert.Equal(t, results["ROOT_CERT"], results["ROOT_CERT_CACHED"])
+		delete(results, "ROOT_CERT")
+		delete(results, "ROOT_CERT_CACHED")
+
+		inlineCerts := strings.Split(results["INLINE_DYNAMIC_SECRET"], "__")
+		require.Equal(t, 2, len(inlineCerts), "two certs are expected")
+		assert.Equal(t, inlineCerts[0], inlineCerts[1], "the two certs should be the same")
+		delete(results, "INLINE_DYNAMIC_SECRET")
+
+		assert.Equal(t, map[string]string{
+			"ACCOUNT_PASSWORD_1":              "secret1",
+			"ACCOUNT_PASSWORD":                "secret",
+			"TRANSIT_SECRET":                  "secret",
+			"INLINE_SECRET":                   "scheme://superusername:secret@127.0.0.1:8080",
+			"INLINE_SECRET_EMBEDDED_TEMPLATE": "scheme://superusername:secret@127.0.0.1:8080",
+		}, results)
+	})
+
+	t.Run("correct path but missing secret", func(t *testing.T) {
+		t.Parallel()
 
-// 	t.Run("correct path but missing secret", func(t *testing.T) {
-// 		t.Parallel()
+		references := map[string]string{
+			"SECRET": "bao:secret/data/supersecret#password",
+		}
 
-// 		references := map[string]string{
-// 			"SECRET": "bao:secret/data/supersecret#password",
-// 		}
+		results := map[string]string{}
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
 
-// 		results := map[string]string{}
-// 		injectFunc := func(key, value string) {
-// 			assertKeyDoesNotExist(t, results, key)
-// 			results[key] = value
-// 		}
+		err := injector.InjectSecretsFromBao(references, injectFunc)
+		assert.EqualError(t, err, "path not found: secret/data/supersecret")
+	})
 
-// 		err := injector.InjectSecretsFromBao(references, injectFunc)
-// 		assert.EqualError(t, err, "path not found: secret/data/supersecret")
-// 	})
+	t.Run("incorrect kv2 path", func(t *testing.T) {
+		t.Parallel()
 
-// 	t.Run("incorrect kv2 path", func(t *testing.T) {
-// 		t.Parallel()
+		references := map[string]string{
+			"SECRET": "bao:secret/get/data#data",
+		}
 
-// 		references := map[string]string{
-// 			"SECRET": "bao:secret/get/data#data",
-// 		}
+		results := map[string]string{}
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
 
-// 		results := map[string]string{}
-// 		injectFunc := func(key, value string) {
-// 			assertKeyDoesNotExist(t, results, key)
-// 			results[key] = value
-// 		}
+		err := injector.InjectSecretsFromBao(references, injectFunc)
+		assert.EqualError(t, err, "path not found: secret/get/data")
+	})
+}
 
-// 		err := injector.InjectSecretsFromBao(references, injectFunc)
-// 		assert.EqualError(t, err, "path not found: secret/get/data")
-// 	})
-// }
+func TestSecretInjectorFromPath(t *testing.T) {
+	if addr := os.Getenv("BAO_ADDR"); addr == "" {
+		t.Skip("skipping test: no BAO_ADDR environment variable is set")
+	}
 
-// func TestSecretInjectorFromPath(t *testing.T) {
-// 	if addr := os.Getenv("BAO_ADDR"); addr == "" {
-// 		t.Skip("skipping test: no BAO_ADDR environment variable is set")
-// 	}
+	if testing.Short() {
+		t.Skip("skipping integration test due to -short")
+	}
 
-// 	if testing.Short() {
-// 		t.Skip("skipping integration test due to -short")
-// 	}
+	config := baoapi.DefaultConfig()
+	if config.Error != nil {
+		assert.NoError(t, config.Error)
+	}
 
-// 	config := baoapi.DefaultConfig()
-// 	if config.Error != nil {
-// 		assert.NoError(t, config.Error)
-// 	}
+	client, err := bao.NewClientFromConfig(config)
+	assert.NoError(t, err)
 
-// 	client, err := bao.NewClientFromConfig(config)
-// 	assert.NoError(t, err)
+	_, err = client.RawClient().Logical().Write("secret/data/account1", bao.NewData(0, map[string]interface{}{"password": "secret", "password2": "secret1"}))
+	assert.NoError(t, err)
 
-// 	_, err = client.RawClient().Logical().Write("secret/data/account1", bao.NewData(0, map[string]interface{}{"password": "secret", "password2": "secret1"}))
-// 	assert.NoError(t, err)
-
-// 	_, err = client.RawClient().Logical().Write("secret/data/account1", bao.NewData(1, map[string]interface{}{"password": "secret", "password2": "secret2"}))
-// 	assert.NoError(t, err)
+	_, err = client.RawClient().Logical().Write("secret/data/account1", bao.NewData(1, map[string]interface{}{"password": "secret", "password2": "secret2"}))
+	assert.NoError(t, err)
 
-// 	_, err = client.RawClient().Logical().Write("secret/data/account2", bao.NewData(0, map[string]interface{}{"password3": "secret", "password4": "secret2"}))
-// 	assert.NoError(t, err)
+	_, err = client.RawClient().Logical().Write("secret/data/account2", bao.NewData(0, map[string]interface{}{"password3": "secret", "password4": "secret2"}))
+	assert.NoError(t, err)
 
-// 	t.Cleanup(func() {
-// 		_, err = client.RawClient().Logical().Delete("secret/metadata/account1")
-// 		assert.NoError(t, err)
-// 		_, err = client.RawClient().Logical().Delete("secret/metadata/account2")
-// 		assert.NoError(t, err)
-// 	})
+	t.Cleanup(func() {
+		_, err = client.RawClient().Logical().Delete("secret/metadata/account1")
+		assert.NoError(t, err)
+		_, err = client.RawClient().Logical().Delete("secret/metadata/account2")
+		assert.NoError(t, err)
+	})
 
-// 	injector := NewSecretInjector(Config{}, client, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	injector := NewSecretInjector(Config{}, client, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-// 	t.Run("success", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 
-// 		paths := "secret/data/account1"
+		paths := "secret/data/account1"
 
-// 		results := map[string]string{}
+		results := map[string]string{}
 
-// 		injectFunc := func(key, value string) {
-// 			assertKeyDoesNotExist(t, results, key)
-// 			results[key] = value
-// 		}
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
 
-// 		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
-// 		require.NoError(t, err)
+		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
+		require.NoError(t, err)
 
-// 		assert.Equal(t, map[string]string{
-// 			"password":  "secret",
-// 			"password2": "secret2",
-// 		}, results)
-// 	})
+		assert.Equal(t, map[string]string{
+			"password":  "secret",
+			"password2": "secret2",
+		}, results)
+	})
 
-// 	t.Run("success specific version", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("success specific version", func(t *testing.T) {
+		t.Parallel()
 
-// 		paths := "secret/data/account1#1"
+		paths := "secret/data/account1#1"
 
-// 		results := map[string]string{}
+		results := map[string]string{}
 
-// 		injectFunc := func(key, value string) {
-// 			assertKeyDoesNotExist(t, results, key)
-// 			results[key] = value
-// 		}
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
 
-// 		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
-// 		require.NoError(t, err)
+		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
+		require.NoError(t, err)
 
-// 		assert.Equal(t, map[string]string{
-// 			"password":  "secret",
-// 			"password2": "secret1",
-// 		}, results)
-// 	})
+		assert.Equal(t, map[string]string{
+			"password":  "secret",
+			"password2": "secret1",
+		}, results)
+	})
 
-// 	t.Run("success multiple paths", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("success multiple paths", func(t *testing.T) {
+		t.Parallel()
 
-// 		paths := "secret/data/account1,secret/data/account2"
-// 		results := map[string]string{}
+		paths := "secret/data/account1,secret/data/account2"
+		results := map[string]string{}
 
-// 		injectFunc := func(key, value string) {
-// 			assertKeyDoesNotExist(t, results, key)
-// 			results[key] = value
-// 		}
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
 
-// 		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
-// 		require.NoError(t, err)
+		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
+		require.NoError(t, err)
 
-// 		assert.Equal(t, map[string]string{
-// 			"password":  "secret",
-// 			"password2": "secret2",
-// 			"password3": "secret",
-// 			"password4": "secret2",
-// 		}, results)
-// 	})
+		assert.Equal(t, map[string]string{
+			"password":  "secret",
+			"password2": "secret2",
+			"password3": "secret",
+			"password4": "secret2",
+		}, results)
+	})
 
-// 	t.Run("success multiple paths, specific version", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("success multiple paths, specific version", func(t *testing.T) {
+		t.Parallel()
 
-// 		paths := "secret/data/account1#1,secret/data/account2"
-// 		results := map[string]string{}
+		paths := "secret/data/account1#1,secret/data/account2"
+		results := map[string]string{}
 
-// 		injectFunc := func(key, value string) {
-// 			assertKeyDoesNotExist(t, results, key)
-// 			results[key] = value
-// 		}
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
 
-// 		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
-// 		require.NoError(t, err)
+		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
+		require.NoError(t, err)
 
-// 		assert.Equal(t, map[string]string{
-// 			"password":  "secret",
-// 			"password2": "secret1",
-// 			"password3": "secret",
-// 			"password4": "secret2",
-// 		}, results)
-// 	})
+		assert.Equal(t, map[string]string{
+			"password":  "secret",
+			"password2": "secret1",
+			"password3": "secret",
+			"password4": "secret2",
+		}, results)
+	})
 
-// 	t.Run("incorrect kv2 path", func(t *testing.T) {
-// 		t.Parallel()
+	t.Run("incorrect kv2 path", func(t *testing.T) {
+		t.Parallel()
 
-// 		paths := "secret/data/doesnotexist"
+		paths := "secret/data/doesnotexist"
 
-// 		results := map[string]string{}
-// 		injectFunc := func(key, value string) {
-// 			assertKeyDoesNotExist(t, results, key)
-// 			results[key] = value
-// 		}
+		results := map[string]string{}
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
 
-// 		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
-// 		assert.EqualError(t, err, "path not found: secret/data/doesnotexist")
+		err := injector.InjectSecretsFromBaoPath(paths, injectFunc)
+		assert.EqualError(t, err, "path not found: secret/data/doesnotexist")
 
-// 		assert.Equal(t, map[string]string{}, results)
-// 	})
-// }
+		assert.Equal(t, map[string]string{}, results)
+	})
+}
 
 func TestPaginate(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Overview

- Due to misconfigurations related to OpenBao still being dependent on Vault, using them together in a common job, makes them bump into each-other, thats why they are tested in separate jobs.

Fixes: #421 